### PR TITLE
fix/remove-nitro-prerender

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -42,10 +42,6 @@ export default defineNuxtConfig({
   },
 
   nitro: {
-    prerender: {
-      routes: ['/'],
-      crawlLinks: true
-    },
     routeRules: {
       '/**': {
         headers: {


### PR DESCRIPTION
refactor: Remove prerender configuration from nitro settings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated prerendering configuration that affects how static pages are generated during the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->